### PR TITLE
Your ESLint plugin has not included a URL for a rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -415,9 +415,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
-      "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1921,10 +1921,21 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        }
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -1933,9 +1944,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.0.82",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.82.tgz",
-      "integrity": "sha512-vakh2il2Q9QdwCUEiFQqtamOANcGATh5OlMRLaXsvOhuuzr/SXdngYw1rwJjesrljbnsq3+UZ5+3Y3uszc/U/w==",
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
     "espower-location-detector": {
@@ -2359,7 +2370,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2380,12 +2392,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2400,17 +2414,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2527,7 +2544,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2539,6 +2557,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2553,6 +2572,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2560,12 +2580,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2584,6 +2606,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2664,7 +2687,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2676,6 +2700,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2761,7 +2786,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2797,6 +2823,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2816,6 +2843,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2859,12 +2887,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3704,9 +3734,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3815,9 +3845,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -3885,15 +3915,15 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.snakecase": {
@@ -4087,9 +4117,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -4247,6 +4277,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4818,8 +4849,7 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "foreground-child": {
           "version": "1.5.6",
@@ -5189,7 +5219,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -5293,25 +5324,6 @@
           "version": "0.0.8",
           "bundled": true,
           "dev": true
-        },
-        "mixin-deep": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
         },
         "mkdirp": {
           "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-lodash-fp",
-  "version": "2.2",
+  "version": "2.2.0",
   "description": "ESLint rules for lodash/fp",
   "license": "MIT",
   "repository": "jfmengels/eslint-plugin-lodash-fp",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "arrowParens": "avoid",
     "printWidth": 120,
     "proseWrap": "preserve",
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "bracketSpacing": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "eslint-plugin-lodash-fp",
-  "version": "2.1.3",
+  "version": "2.2",
   "description": "ESLint rules for lodash/fp",
   "license": "MIT",
   "repository": "jfmengels/eslint-plugin-lodash-fp",
   "author": {
     "name": "Jeroen Engels",
     "email": "jfm.engels@gmail.com",
-    "url": "github.com/jfmengels"
+    "url": "https://github.com/jfmengels"
   },
   "engines": {
     "node": ">=6.0.0"
@@ -55,5 +55,12 @@
   "xo": {
     "exnext": true,
     "space": 2
+  },
+  "prettier": {
+    "singleQuote": true,
+    "arrowParens": "avoid",
+    "printWidth": 120,
+    "proseWrap": "preserve",
+    "trailingComma": "none"
   }
 }

--- a/rules/consistent-compose.js
+++ b/rules/consistent-compose.js
@@ -35,7 +35,6 @@ module.exports = {
       description: 'Enforce a consistent composition method.',
       recommended: 'off',
 
-      // consistent-compose.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/consistent-compose.md'
     }
   }

--- a/rules/consistent-compose.js
+++ b/rules/consistent-compose.js
@@ -20,10 +20,12 @@ const create = function (context) {
   });
 };
 
-const schema = [{
-  type: 'string',
-  enum: constants.COMPOSITION_METHODS
-}];
+const schema = [
+  {
+    type: 'string',
+    enum: constants.COMPOSITION_METHODS
+  }
+];
 
 module.exports = {
   create,
@@ -31,7 +33,10 @@ module.exports = {
     schema,
     docs: {
       description: 'Enforce a consistent composition method.',
-      recommended: 'off'
+      recommended: 'off',
+
+      // consistent-compose.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/consistent-compose.md'
     }
   }
 };

--- a/rules/consistent-name.js
+++ b/rules/consistent-name.js
@@ -35,7 +35,8 @@ const create = function (context) {
     },
     'Program:exit'() {
       const importValues = _.values(info.imports);
-      if (// `lodash`/`lodash/fp` was imported
+      if (
+        // `lodash`/`lodash/fp` was imported
         (importValues.indexOf('') !== -1 || importValues.indexOf('fp') !== -1) &&
         // But <expectedName> does not refer to either `lodash` or `lodash/fp`
         !info.helpers.isAnyLodash(expectedName)
@@ -46,9 +47,11 @@ const create = function (context) {
   });
 };
 
-const schema = [{
-  type: 'string'
-}];
+const schema = [
+  {
+    type: 'string'
+  }
+];
 
 module.exports = {
   create,
@@ -56,7 +59,10 @@ module.exports = {
     schema,
     docs: {
       description: 'Enforce a consistent name for Lodash.',
-      recommended: ['error', '_']
+      recommended: ['error', '_'],
+
+      // consistent-name.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/consistent-name.md'
     }
   }
 };

--- a/rules/consistent-name.js
+++ b/rules/consistent-name.js
@@ -61,7 +61,6 @@ module.exports = {
       description: 'Enforce a consistent name for Lodash.',
       recommended: ['error', '_'],
 
-      // consistent-name.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/consistent-name.md'
     }
   }

--- a/rules/no-argumentless-calls.js
+++ b/rules/no-argumentless-calls.js
@@ -28,7 +28,6 @@ module.exports = {
       description: 'Forbid argument-less calls of Lodash methods.',
       recommended: 'error',
 
-      // no-argumentless-calls.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-argumentless-calls.md'
     }
   }

--- a/rules/no-argumentless-calls.js
+++ b/rules/no-argumentless-calls.js
@@ -26,7 +26,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid argument-less calls of Lodash methods.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-argumentless-calls.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-argumentless-calls.md'
     }
   }
 };

--- a/rules/no-chain.js
+++ b/rules/no-chain.js
@@ -8,11 +8,11 @@ function isLodashWrap(helpers, node) {
 
 const create = function (context) {
   const info = enhance();
-  const { helpers } = info;
+  const {helpers} = info;
 
   return info.merge({
     CallExpression(node) {
-      const { callee } = node;
+      const {callee} = node;
       if (isLodashWrap(helpers, callee) || info.helpers.isAnyMethodOf('chain', callee)) {
         context.report(node, 'Unallowed use of chain operations. Use flow/compose instead');
       }
@@ -27,7 +27,6 @@ module.exports = {
       description: 'Forbid the use of [`_.chain`](https://lodash.com/docs#chain)',
       recommended: 'error',
 
-      // no-chain.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-chain.md'
     }
   }

--- a/rules/no-chain.js
+++ b/rules/no-chain.js
@@ -3,17 +3,16 @@
 const enhance = require('./core/enhance');
 
 function isLodashWrap(helpers, node) {
-  return node.type === 'Identifier' &&
-    helpers.isAnyLodash(node.name);
+  return node.type === 'Identifier' && helpers.isAnyLodash(node.name);
 }
 
 const create = function (context) {
   const info = enhance();
-  const {helpers} = info;
+  const { helpers } = info;
 
   return info.merge({
     CallExpression(node) {
-      const {callee} = node;
+      const { callee } = node;
       if (isLodashWrap(helpers, callee) || info.helpers.isAnyMethodOf('chain', callee)) {
         context.report(node, 'Unallowed use of chain operations. Use flow/compose instead');
       }
@@ -26,7 +25,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of [`_.chain`](https://lodash.com/docs#chain)',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-chain.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-chain.md'
     }
   }
 };

--- a/rules/no-extraneous-args.js
+++ b/rules/no-extraneous-args.js
@@ -43,7 +43,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'No extraneous arguments to methods with a fixed arity.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-extraneous-args.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-extraneous-args.md'
     }
   }
 };

--- a/rules/no-extraneous-args.js
+++ b/rules/no-extraneous-args.js
@@ -45,7 +45,6 @@ module.exports = {
       description: 'No extraneous arguments to methods with a fixed arity.',
       recommended: 'error',
 
-      // no-extraneous-args.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-extraneous-args.md'
     }
   }

--- a/rules/no-extraneous-function-wrapping.js
+++ b/rules/no-extraneous-function-wrapping.js
@@ -21,7 +21,7 @@ function isExtraneous(info, argNode) {
   const lastArgName = argNode.params[0].name;
   let callExpression;
   if (argNode.body.type === 'BlockStatement') {
-    const { body } = argNode.body;
+    const {body} = argNode.body;
     if (body.length !== 1 || body[0].type !== 'ReturnStatement' || body[0].argument === null) {
       return false;
     }
@@ -85,7 +85,6 @@ module.exports = {
       description: 'Avoid unnecessary function wrapping.',
       recommended: 'error',
 
-      // no-extraneous-function-wrapping.js
       url:
         'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-extraneous-function-wrapping.md'
     }

--- a/rules/no-extraneous-function-wrapping.js
+++ b/rules/no-extraneous-function-wrapping.js
@@ -10,8 +10,7 @@ const isFunction = _.flow(
 );
 
 function hasSingleIdentifierParam(node) {
-  return node.params.length === 1 &&
-    node.params[0].type === 'Identifier';
+  return node.params.length === 1 && node.params[0].type === 'Identifier';
 }
 
 function isExtraneous(info, argNode) {
@@ -22,7 +21,7 @@ function isExtraneous(info, argNode) {
   const lastArgName = argNode.params[0].name;
   let callExpression;
   if (argNode.body.type === 'BlockStatement') {
-    const {body} = argNode.body;
+    const { body } = argNode.body;
     if (body.length !== 1 || body[0].type !== 'ReturnStatement' || body[0].argument === null) {
       return false;
     }
@@ -32,7 +31,8 @@ function isExtraneous(info, argNode) {
   }
 
   // If <SOMETHING> is not a call expression
-  if (callExpression.type !== 'CallExpression' ||
+  if (
+    callExpression.type !== 'CallExpression' ||
     // Or if `lastArgName` is used somewhere else in the function
     astUtils.containsIdentifier(lastArgName, callExpression.callee) ||
     // Or in `lastArgName` is used among the other arguments
@@ -52,9 +52,7 @@ function isExtraneous(info, argNode) {
   }
   const calleeArgs = callExpression.arguments;
   const lastCalleeArg = calleeArgs[calleeArgs.length - 1];
-  return lastCalleeArg &&
-    lastCalleeArg.type === 'Identifier' &&
-    lastCalleeArg.name === lastArgName;
+  return lastCalleeArg && lastCalleeArg.type === 'Identifier' && lastCalleeArg.name === lastArgName;
 }
 
 const errorMessage = 'Found extraneous function wrap around curried method. Pass inner function directly';
@@ -85,7 +83,11 @@ module.exports = {
   meta: {
     docs: {
       description: 'Avoid unnecessary function wrapping.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-extraneous-function-wrapping.js
+      url:
+        'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-extraneous-function-wrapping.md'
     }
   }
 };

--- a/rules/no-extraneous-iteratee-args.js
+++ b/rules/no-extraneous-iteratee-args.js
@@ -23,9 +23,11 @@ const create = function (context) {
 
       const nArgs = getFunctionArgumentsLength(node.arguments[method.iterateePos]);
       if (nArgs > method.iterateeAry) {
-        context.report(node,
+        context.report(
+          node,
           `Too many parameters in \`${method.name}\`'s iteratee, it is only given ` +
-          `${method.iterateeAry} argument${method.iterateeAry === 1 ? '' : 's'}.`);
+            `${method.iterateeAry} argument${method.iterateeAry === 1 ? '' : 's'}.`
+        );
       }
     }
   });
@@ -36,7 +38,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'No extraneous parameters in iteratees.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-extraneous-iteratee-args.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-extraneous-iteratee-args.md'
     }
   }
 };

--- a/rules/no-extraneous-iteratee-args.js
+++ b/rules/no-extraneous-iteratee-args.js
@@ -40,7 +40,6 @@ module.exports = {
       description: 'No extraneous parameters in iteratees.',
       recommended: 'error',
 
-      // no-extraneous-iteratee-args.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-extraneous-iteratee-args.md'
     }
   }

--- a/rules/no-extraneous-partials.js
+++ b/rules/no-extraneous-partials.js
@@ -3,14 +3,14 @@
 const _ = require('lodash/fp');
 const enhance = require('./core/enhance');
 
-const hasSpread = _.flow(_.get('arguments'), _.some({ type: 'SpreadElement' }));
+const hasSpread = _.flow(_.get('arguments'), _.some({type: 'SpreadElement'}));
 
 const create = function (context) {
   const info = enhance();
 
   return info.merge({
     CallExpression(node) {
-      const { callee } = node;
+      const {callee} = node;
       const method = info.helpers.isMethodCall(callee);
       if (method && !method.skipFixed && (callee.arguments.length || 1) < method.ary && !hasSpread(callee)) {
         context.report(node, `\`${method.name}\` should be called without an intermediate partial.`);
@@ -26,7 +26,6 @@ module.exports = {
       description: 'Avoid unnecessary intermediate partials in curried methods.',
       recommended: 'off',
 
-      // no-extraneous-partials.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-extraneous-partials.md'
     }
   }

--- a/rules/no-extraneous-partials.js
+++ b/rules/no-extraneous-partials.js
@@ -3,17 +3,14 @@
 const _ = require('lodash/fp');
 const enhance = require('./core/enhance');
 
-const hasSpread = _.flow(
-  _.get('arguments'),
-  _.some({type: 'SpreadElement'}),
-);
+const hasSpread = _.flow(_.get('arguments'), _.some({ type: 'SpreadElement' }));
 
 const create = function (context) {
   const info = enhance();
 
   return info.merge({
     CallExpression(node) {
-      const {callee} = node;
+      const { callee } = node;
       const method = info.helpers.isMethodCall(callee);
       if (method && !method.skipFixed && (callee.arguments.length || 1) < method.ary && !hasSpread(callee)) {
         context.report(node, `\`${method.name}\` should be called without an intermediate partial.`);
@@ -27,7 +24,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'Avoid unnecessary intermediate partials in curried methods.',
-      recommended: 'off'
+      recommended: 'off',
+
+      // no-extraneous-partials.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-extraneous-partials.md'
     }
   }
 };

--- a/rules/no-for-each.js
+++ b/rules/no-for-each.js
@@ -5,7 +5,7 @@ const enhance = require('./core/enhance');
 
 const isForEachCall = _.matches({
   type: 'MemberExpression',
-  property: { name: 'forEach' }
+  property: {name: 'forEach'}
 });
 
 const create = function (context) {
@@ -47,7 +47,6 @@ module.exports = {
       description: ' Forbid the use of [`_.forEach`](https://lodash.com/docs#forEach)',
       recommended: 'off',
 
-      // no-for-each.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-for-each.md'
     }
   }

--- a/rules/no-for-each.js
+++ b/rules/no-for-each.js
@@ -3,7 +3,10 @@
 const _ = require('lodash/fp');
 const enhance = require('./core/enhance');
 
-const isForEachCall = _.matches({type: 'MemberExpression', property: {name: 'forEach'}});
+const isForEachCall = _.matches({
+  type: 'MemberExpression',
+  property: { name: 'forEach' }
+});
 
 const create = function (context) {
   const info = enhance();
@@ -42,7 +45,10 @@ module.exports = {
     schema,
     docs: {
       description: ' Forbid the use of [`_.forEach`](https://lodash.com/docs#forEach)',
-      recommended: 'off'
+      recommended: 'off',
+
+      // no-for-each.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-for-each.md'
     }
   }
 };

--- a/rules/no-partial-of-curried.js
+++ b/rules/no-partial-of-curried.js
@@ -25,7 +25,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'No use of [`_.partial`](https://lodash.com/docs#partial) on curried Lodash methods.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-partial-of-curried.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-partial-of-curried.md'
     }
   }
 };

--- a/rules/no-partial-of-curried.js
+++ b/rules/no-partial-of-curried.js
@@ -27,7 +27,6 @@ module.exports = {
       description: 'No use of [`_.partial`](https://lodash.com/docs#partial) on curried Lodash methods.',
       recommended: 'error',
 
-      // no-partial-of-curried.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-partial-of-curried.md'
     }
   }

--- a/rules/no-single-composition.js
+++ b/rules/no-single-composition.js
@@ -34,7 +34,6 @@ module.exports = {
       description: 'Enforce at least two methods arguments for composition methods.',
       recommended: 'error',
 
-      // no-single-composition.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-single-composition.md'
     }
   }

--- a/rules/no-single-composition.js
+++ b/rules/no-single-composition.js
@@ -32,7 +32,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'Enforce at least two methods arguments for composition methods.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-single-composition.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-single-composition.md'
     }
   }
 };

--- a/rules/no-submodule-destructuring.js
+++ b/rules/no-submodule-destructuring.js
@@ -4,8 +4,8 @@ const _ = require('lodash/fp');
 const astUtils = require('eslint-ast-utils');
 const enhance = require('./core/enhance');
 
-const isImportSpecifier = _.matches({type: 'ImportSpecifier'});
-const isObjectPattern = _.matches({type: 'ObjectPattern'});
+const isImportSpecifier = _.matches({ type: 'ImportSpecifier' });
+const isObjectPattern = _.matches({ type: 'ObjectPattern' });
 
 const errorMessage = 'Import of Lodash submodule should not be destructured';
 
@@ -14,9 +14,7 @@ function isLodashSubModule(source) {
 }
 
 function isRequireOfLodashSubModule(node) {
-  return astUtils.isStaticRequire(node) &&
-    node.arguments.length > 0 &&
-    isLodashSubModule(node.arguments[0].value);
+  return astUtils.isStaticRequire(node) && node.arguments.length > 0 && isLodashSubModule(node.arguments[0].value);
 }
 
 const create = function (context) {
@@ -44,7 +42,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid destructuring of Lodash submodules.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-submodule-destructuring.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-submodule-destructuring.md'
     }
   }
 };

--- a/rules/no-submodule-destructuring.js
+++ b/rules/no-submodule-destructuring.js
@@ -4,8 +4,8 @@ const _ = require('lodash/fp');
 const astUtils = require('eslint-ast-utils');
 const enhance = require('./core/enhance');
 
-const isImportSpecifier = _.matches({ type: 'ImportSpecifier' });
-const isObjectPattern = _.matches({ type: 'ObjectPattern' });
+const isImportSpecifier = _.matches({type: 'ImportSpecifier'});
+const isObjectPattern = _.matches({type: 'ObjectPattern'});
 
 const errorMessage = 'Import of Lodash submodule should not be destructured';
 
@@ -44,7 +44,6 @@ module.exports = {
       description: 'Forbid destructuring of Lodash submodules.',
       recommended: 'error',
 
-      // no-submodule-destructuring.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-submodule-destructuring.md'
     }
   }

--- a/rules/no-unused-result.js
+++ b/rules/no-unused-result.js
@@ -4,10 +4,7 @@ const _ = require('lodash/fp');
 const enhance = require('./core/enhance');
 const constants = require('./core/constants');
 
-const isForEach = _.flow(
-  _.get('realName'),
-  _.includes(_, constants.SIDE_EFFECT_METHODS)
-);
+const isForEach = _.flow(_.get('realName'), _.includes(_, constants.SIDE_EFFECT_METHODS));
 
 function isMethodCall(info, node) {
   const method = info.helpers.isMethodCall(node);
@@ -38,7 +35,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'Enforce that the result of a Lodash method call gets used.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // no-unused-result.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-unused-result.md'
     }
   }
 };

--- a/rules/no-unused-result.js
+++ b/rules/no-unused-result.js
@@ -37,7 +37,6 @@ module.exports = {
       description: 'Enforce that the result of a Lodash method call gets used.',
       recommended: 'error',
 
-      // no-unused-result.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/no-unused-result.md'
     }
   }

--- a/rules/prefer-compact.js
+++ b/rules/prefer-compact.js
@@ -33,7 +33,6 @@ module.exports = {
         'Prefer [`_.compact`](https://lodash.com/docs#compact) over [`_.filter`](https://lodash.com/docs#filter) with identity function.',
       recommended: 'error',
 
-      // prefer-compact.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-compact.md'
     }
   }

--- a/rules/prefer-compact.js
+++ b/rules/prefer-compact.js
@@ -9,8 +9,7 @@ const create = function (context) {
   const isFilterCall = info.helpers.isMethodCallOf('filter');
 
   function isIdentity(node) {
-    return info.helpers.isMethodOf('identity', node) ||
-      astUtil.isIdentityFunction(node);
+    return info.helpers.isMethodOf('identity', node) || astUtil.isIdentityFunction(node);
   }
 
   function isFilterWithIdentity(node) {
@@ -30,8 +29,12 @@ module.exports = {
   create,
   meta: {
     docs: {
-      description: 'Prefer [`_.compact`](https://lodash.com/docs#compact) over [`_.filter`](https://lodash.com/docs#filter) with identity function.',
-      recommended: 'error'
+      description:
+        'Prefer [`_.compact`](https://lodash.com/docs#compact) over [`_.filter`](https://lodash.com/docs#filter) with identity function.',
+      recommended: 'error',
+
+      // prefer-compact.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-compact.md'
     }
   }
 };

--- a/rules/prefer-composition-grouping.js
+++ b/rules/prefer-composition-grouping.js
@@ -53,7 +53,6 @@ module.exports = {
       description: 'Prefer grouping similar methods in composition methods.',
       recommended: 'error',
 
-      // prefer-composition-grouping.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-composition-grouping.md'
     }
   }

--- a/rules/prefer-composition-grouping.js
+++ b/rules/prefer-composition-grouping.js
@@ -51,7 +51,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'Prefer grouping similar methods in composition methods.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // prefer-composition-grouping.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-composition-grouping.md'
     }
   }
 };

--- a/rules/prefer-constant.js
+++ b/rules/prefer-constant.js
@@ -58,9 +58,8 @@ module.exports = {
     schema,
     docs: {
       description: 'Prefer [`_.constant`](https://lodash.com/docs#constant) over functions returning literals.',
-      recommended: ['error', { arrowFunctions: false }],
+      recommended: ['error', {arrowFunctions: false}],
 
-      // prefer-constant.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-constant.md'
     }
   }

--- a/rules/prefer-constant.js
+++ b/rules/prefer-constant.js
@@ -15,7 +15,9 @@ const create = function (context) {
       case 'UnaryExpression':
         return isCompletelyLiteral(node.argument);
       case 'ConditionalExpression':
-        return isCompletelyLiteral(node.test) && isCompletelyLiteral(node.consequent) && isCompletelyLiteral(node.alternate);
+        return (
+          isCompletelyLiteral(node.test) && isCompletelyLiteral(node.consequent) && isCompletelyLiteral(node.alternate)
+        );
       default:
         return false;
     }
@@ -56,7 +58,10 @@ module.exports = {
     schema,
     docs: {
       description: 'Prefer [`_.constant`](https://lodash.com/docs#constant) over functions returning literals.',
-      recommended: ['error', {arrowFunctions: false}]
+      recommended: ['error', { arrowFunctions: false }],
+
+      // prefer-constant.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-constant.md'
     }
   }
 };

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -59,7 +59,6 @@ module.exports = {
         'Prefer [`_.flatMap`](https://lodash.com/docs#flatMap) over consecutive [`_.map`](https://lodash.com/docs#map) and [`_.flatten`](https://lodash.com/docs#flatten).',
       recommended: 'error',
 
-      // prefer-flat-map.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-flat-map.md'
     }
   }

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -55,8 +55,12 @@ module.exports = {
   create,
   meta: {
     docs: {
-      description: 'Prefer [`_.flatMap`](https://lodash.com/docs#flatMap) over consecutive [`_.map`](https://lodash.com/docs#map) and [`_.flatten`](https://lodash.com/docs#flatten).',
-      recommended: 'error'
+      description:
+        'Prefer [`_.flatMap`](https://lodash.com/docs#flatMap) over consecutive [`_.map`](https://lodash.com/docs#map) and [`_.flatten`](https://lodash.com/docs#flatten).',
+      recommended: 'error',
+
+      // prefer-flat-map.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-flat-map.md'
     }
   }
 };

--- a/rules/prefer-get.js
+++ b/rules/prefer-get.js
@@ -18,7 +18,7 @@ const create = function (context) {
 
   const expStates = [];
   function getState() {
-    return expStates[expStates.length - 1] || { depth: 0 };
+    return expStates[expStates.length - 1] || {depth: 0};
   }
 
   /* eslint quote-props: [2, "as-needed"] */
@@ -28,7 +28,7 @@ const create = function (context) {
       const rightMemberExp = astUtil.isEqEqEq(node.right) && state.depth === 0 ? node.right.left : node.right;
 
       if (shouldCheckDeeper(node, rightMemberExp, state.node)) {
-        expStates.push({ depth: state.depth + 1, node: rightMemberExp.object });
+        expStates.push({depth: state.depth + 1, node: rightMemberExp.object});
         if (astUtil.isEquivalentExp(node.left, rightMemberExp.object) && state.depth >= ruleDepth - 2) {
           context.report(node, 'Prefer `_.get` or `_.has` over an `&&` chain');
         }
@@ -58,7 +58,6 @@ module.exports = {
       description: 'Prefer [`_.get`](https://lodash.com/docs#get) over multiple `&&`.',
       recommended: 'error',
 
-      // prefer-get.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-get.md'
     }
   }

--- a/rules/prefer-get.js
+++ b/rules/prefer-get.js
@@ -3,11 +3,13 @@
 const astUtil = require('./core/ast-util');
 
 function shouldCheckDeeper(node, nodeRight, toCompare) {
-  return node.operator === '&&' &&
+  return (
+    node.operator === '&&' &&
     nodeRight &&
     nodeRight.type === 'MemberExpression' &&
     !astUtil.isComputed(nodeRight) &&
-    (!toCompare || astUtil.isEquivalentExp(nodeRight, toCompare));
+    (!toCompare || astUtil.isEquivalentExp(nodeRight, toCompare))
+  );
 }
 
 const create = function (context) {
@@ -16,7 +18,7 @@ const create = function (context) {
 
   const expStates = [];
   function getState() {
-    return expStates[expStates.length - 1] || {depth: 0};
+    return expStates[expStates.length - 1] || { depth: 0 };
   }
 
   /* eslint quote-props: [2, "as-needed"] */
@@ -26,7 +28,7 @@ const create = function (context) {
       const rightMemberExp = astUtil.isEqEqEq(node.right) && state.depth === 0 ? node.right.left : node.right;
 
       if (shouldCheckDeeper(node, rightMemberExp, state.node)) {
-        expStates.push({depth: state.depth + 1, node: rightMemberExp.object});
+        expStates.push({ depth: state.depth + 1, node: rightMemberExp.object });
         if (astUtil.isEquivalentExp(node.left, rightMemberExp.object) && state.depth >= ruleDepth - 2) {
           context.report(node, 'Prefer `_.get` or `_.has` over an `&&` chain');
         }
@@ -54,7 +56,10 @@ module.exports = {
     schema,
     docs: {
       description: 'Prefer [`_.get`](https://lodash.com/docs#get) over multiple `&&`.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // prefer-get.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-get.md'
     }
   }
 };

--- a/rules/prefer-identity.js
+++ b/rules/prefer-identity.js
@@ -40,9 +40,8 @@ module.exports = {
     schema,
     docs: {
       description: 'Prefer [`_.identity`](https://lodash.com/docs#identity) over functions returning their argument.',
-      recommended: ['error', { arrowFunctions: false }],
+      recommended: ['error', {arrowFunctions: false}],
 
-      // prefer-identity.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-identity.md'
     }
   }

--- a/rules/prefer-identity.js
+++ b/rules/prefer-identity.js
@@ -40,7 +40,10 @@ module.exports = {
     schema,
     docs: {
       description: 'Prefer [`_.identity`](https://lodash.com/docs#identity) over functions returning their argument.',
-      recommended: ['error', {arrowFunctions: false}]
+      recommended: ['error', { arrowFunctions: false }],
+
+      // prefer-identity.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/prefer-identity.md'
     }
   }
 };

--- a/rules/preferred-alias.js
+++ b/rules/preferred-alias.js
@@ -5,18 +5,22 @@ const data = require('./core/lodash-data');
 const enhance = require('./core/enhance');
 
 function checkOverrides(overrides) {
-  overrides.map(override => {
-    return {
-      override,
-      target: data.aliasToReal[override] || override
-    };
-  }).reduce((res, item) => {
-    if (res[item.target]) {
-      throw new Error(`\`override\` contains \`${res[item.target]}\` and \`${item.override}\` that target \`${item.target}\``);
-    }
-    res[item.target] = item.override;
-    return res;
-  }, {});
+  overrides
+    .map(override => {
+      return {
+        override,
+        target: data.aliasToReal[override] || override
+      };
+    })
+    .reduce((res, item) => {
+      if (res[item.target]) {
+        throw new Error(
+          `\`override\` contains \`${res[item.target]}\` and \`${item.override}\` that target \`${item.target}\``
+        );
+      }
+      res[item.target] = item.override;
+      return res;
+    }, {});
 }
 
 function wantedAlias(overrides, method) {
@@ -64,7 +68,10 @@ module.exports = {
     schema,
     docs: {
       description: 'Limit the use of aliases.',
-      recommended: 'off'
+      recommended: 'off',
+
+      // preferred-alias.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/preferred-alias.md'
     }
   }
 };

--- a/rules/preferred-alias.js
+++ b/rules/preferred-alias.js
@@ -70,7 +70,6 @@ module.exports = {
       description: 'Limit the use of aliases.',
       recommended: 'off',
 
-      // preferred-alias.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/preferred-alias.md'
     }
   }

--- a/rules/use-fp.js
+++ b/rules/use-fp.js
@@ -31,7 +31,10 @@ module.exports = {
   meta: {
     docs: {
       description: 'Use lodash/fp instead of Lodash.',
-      recommended: 'error'
+      recommended: 'error',
+
+      // use-fp.js
+      url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/use-fp.md'
     }
   }
 };

--- a/rules/use-fp.js
+++ b/rules/use-fp.js
@@ -33,7 +33,6 @@ module.exports = {
       description: 'Use lodash/fp instead of Lodash.',
       recommended: 'error',
 
-      // use-fp.js
       url: 'https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/docs/rules/use-fp.md'
     }
   }


### PR DESCRIPTION
Your ESLint plugin has not included a URL for a rule
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can know where their documentation is without having to resort to external packages to guess. If your plugin hasn't included this metadata, its possible you have an older version that needs to be updated.
https://github.com/ghmcadams/vscode-lintlens/wiki/Missing-Rule-Docs-URL
* Squash changes: Missing Rule Docs URL (#1) 
* Bump lodash.mergewith from 4.6.1 to 4.6.2 
Bumps lodash.mergewith from 4.6.1 to 4.6.2.
* Release notes
* Commits
Signed-off-by: dependabot[bot] support@github.com Bump lodash.mergewith from 4.6.1 to 4.6.2 dependencies closes #76 opened on 7 Nov 2019 by dependabot bot
* Bump mixin-deep from 1.3.1 to 1.3.2
Bumps mixin-deep from 1.3.1 to 1.3.2.
* Release notes
* Commits
Signed-off-by: dependabot[bot] support@github.com Bump mixin-deep from 1.3.1 to 1.3.2 dependencies closes #78 opened on 7 Nov 2019 by dependabot bot
* Bump lodash from 4.17.10 to 4.17.13
Bumps lodash from 4.17.10 to 4.17.13.
* Release notes
* Commits
Signed-off-by: dependabot[bot] support@github.com Bump lodash from 4.17.10 to 4.17.13 dependencies closes #77 opened on 7 Nov 2019 by dependabot bot
* Bump lodash.merge from 4.6.1 to 4.6.2
Bumps lodash.merge from 4.6.1 to 4.6.2.
* Release notes
* Commits
Signed-off-by: dependabot[bot] support@github.com Bump lodash.merge from 4.6.1 to 4.6.2 dependencies closes #79 opened on 7 Nov 2019 by dependabot bot
* Bump eslint-utils from 1.3.1 to 1.4.3
Bumps eslint-utils from 1.3.1 to 1.4.3.
* Release notes
* Commits
Signed-off-by: dependabot[bot] support@github.com Bump eslint-utils from 1.3.1 to 1.4.3 dependencies closes #80 opened on 7 Nov 2019 by dependabot bot
* Bump js-yaml from 3.12.0 to 3.13.1
Bumps js-yaml from 3.12.0 to 3.13.1.
* Release notes
* Changelog
* Commits
Signed-off-by: dependabot[bot] support@github.com Bump js-yaml from 3.12.0 to 3.13.1 dependencies closes #81 opened on 7 Nov 2019 by dependabot bot
* Bump esm from 3.0.82 to 3.2.25
Bumps esm from 3.0.82 to 3.2.25.
* Release notes
* Commits
Signed-off-by: dependabot[bot] support@github.com Bump esm from 3.0.82 to 3.2.25 dependencies closes #82 opened on 7 Nov 2019 by dependabot bot
* Bump acorn from 5.7.2 to 5.7.4
Bumps acorn from 5.7.2 to 5.7.4.
* Release notes
* Commits
Signed-off-by: dependabot[bot] support@github.com Bump acorn from 5.7.2 to 5.7.4 dependencies closes #84 opened on 14 Mar by dependabot bot
* fix(docs): missing rule docs URL
Your ESLint plugin has not included a URL for a rule ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788.
This adds the URL to all the existing rules so anything consuming them can know where their documentation is without having to resort to external packages to guess. If your plugin hasn't included this metadata, its possible you have an older version that needs to be updated.
https://github.com/ghmcadams/vscode-lintlens/wiki/Missing-Rule-Docs-URL Signed-off-by: Benjamin Vincent luxcium@neb401.com
* fix: singleQuote
Signed-off-by: Benjamin Vincent luxcium@neb401.com
* bump: version minor &add prettier rule singleQuote
Signed-off-by: Benjamin Vincent luxcium@neb401.com
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* prettier: fixing back my mistakes ...
Signed-off-by: Benjamin Vincent luxcium@neb401.com
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Bump acorn from 5.7.2 to 5.7.4 dependencies closes #84 opened on 14 Mar by dependabot bot Bump esm from 3.0.82 to 3.2.25 dependencies closes #82 opened on 7 Nov 2019 by dependabot bot Bump js-yaml from 3.12.0 to 3.13.1 dependencies closes #81 opened on 7 Nov 2019 by dependabot bot Bump eslint-utils from 1.3.1 to 1.4.3 dependencies closes #80 opened on 7 Nov 2019 by dependabot bot Bump lodash.merge from 4.6.1 to 4.6.2 dependencies closes #79 opened on 7 Nov 2019 by dependabot bot Bump mixin-deep from 1.3.1 to 1.3.2 dependencies closes #78 opened on 7 Nov 2019 by dependabot bot Bump lodash from 4.17.10 to 4.17.13 dependencies closes #77 opened on 7 Nov 2019 by dependabot bot Bump lodash.mergewith from 4.6.1 to 4.6.2 dependencies closes #76 opened on 7 Nov 2019 by dependabot bot
